### PR TITLE
Phase1

### DIFF
--- a/contracts/GoldMinter.sol
+++ b/contracts/GoldMinter.sol
@@ -622,12 +622,14 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
 
         usdToken.safeTransferFrom(msg.sender, $.usdRecipient, actualUsdAmount);
 
+        uint256 storedMinGoldAmount = tradeUnit_ > 0 ? expectedOutput - feeAmount : _minGoldAmount;
+
         $.mintOrders.push(
             IGoldMinter.MintOrder({
                 buyer: msg.sender,
                 usdToken: address(usdToken),
                 usdAmount: actualUsdAmount,
-                minGoldAmount: tradeUnit_ > 0 ? expectedOutput - feeAmount : _minGoldAmount,
+                minGoldAmount: storedMinGoldAmount,
                 goldAmount: expectedOutput,
                 feeAmount: feeAmount,
                 success: false,
@@ -637,7 +639,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
 
         $.userMintNonces[msg.sender].push(mintNonce);
 
-        emit RequestMint(mintNonce, msg.sender, address(usdToken), actualUsdAmount, _minGoldAmount);
+        emit RequestMint(mintNonce, msg.sender, address(usdToken), actualUsdAmount, storedMinGoldAmount);
 
         if ($.autoSettle) {
             _settleMint(mintNonce, expectedOutput);

--- a/contracts/GoldMinter.sol
+++ b/contracts/GoldMinter.sol
@@ -78,6 +78,8 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         uint16 redeemFee;       // Fee for redeem (e.g., 25 = 0.25%)
         uint256 minMintAmount;  // Minimum gold amount for mint (e.g., 1 ether = 1 gram)
         uint256 minRedeemAmount; // Minimum gold amount for redeem (e.g., 1 ether = 1 gram)
+        uint256 tradeUnit; // 0 = disabled (free amount), >0 = enforced unit (e.g., 1000 ether = 1kg)
+        address feeRecipient; // Gold fee recipient (separate from usdRecipient)
         uint256 minGoldFee;
         uint256 minGoldFeeAmount;
         bool autoSettle;
@@ -127,6 +129,8 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
     event UpdateAutoSettle(bool settle);
     event UpdateTradingLevel(IGoldMinter.Levels level);
     event UpdateRecipient(address newRecipient);
+    event UpdateFeeRecipient(address newFeeRecipient);
+    event UpdateTradeUnit(uint256 tradeUnit);
 
     event AMLBlacklisted(address indexed user, bool blacklisted);
     event EmergencyPaused(address indexed by, bool paused);
@@ -171,6 +175,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         address _USDC,
         address _goldPriceFeed,
         address _usdRecipient,
+        address _feeRecipient,
         address _owner,
         bool _autoSettle
     ) public virtual initializer {
@@ -179,6 +184,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         if (_USDC == address(0)) revert Errors.ZeroUSDC();
         if (_goldPriceFeed == address(0)) revert Errors.ZeroPriceFeed();
         if (_usdRecipient == address(0)) revert Errors.ZeroRecipient();
+        if (_feeRecipient == address(0)) revert Errors.ZeroRecipient();
         if (_owner == address(0)) revert Errors.ZeroOwner();
 
         GoldMinterStorage storage $ = _getGoldMinterStorage();
@@ -200,6 +206,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         $.autoSettle = _autoSettle;
         $.tradeLevel = IGoldMinter.Levels.KYCD;
         $.usdRecipient = _usdRecipient;
+        $.feeRecipient = _feeRecipient;
         $.maxPriceAge = 10 minutes;
         // Oracle price validation limits (ounce-based, matches Oracle format)
         $.minGoldPrice = 500e8; // $500/ounce
@@ -390,6 +397,19 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         emit UpdateRecipient(_usdRecipient);
     }
 
+    function updateFeeRecipient(address _feeRecipient) external onlyRole(INFRA_MANAGER_ROLE) {
+        if (_feeRecipient == address(0)) revert Errors.ZeroRecipient();
+        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        $.feeRecipient = _feeRecipient;
+        emit UpdateFeeRecipient(_feeRecipient);
+    }
+
+    function updateTradeUnit(uint256 _tradeUnit) external onlyRole(PARAMETER_MANAGER_ROLE) {
+        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        $.tradeUnit = _tradeUnit;
+        emit UpdateTradeUnit(_tradeUnit);
+    }
+
     function setAMLBlacklist(address user, bool blacklisted) external onlyRole(KYC_MANAGER_ROLE) {
         GoldMinterStorage storage $ = _getGoldMinterStorage();
         $.amlBlacklist[user] = blacklisted;
@@ -552,6 +572,8 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
     }
 
     /// @notice Request mint with pre-set KYC level (requires approval in advance)
+    /// @dev When tradeUnit > 0 (unit mode): _minGoldAmount = gross gold amount (must be tradeUnit multiple),
+    ///      _usdAmount = maximum USD willing to pay. When tradeUnit == 0 (free mode): current behavior.
     function requestMint(
         address _usdToken,
         uint256 _usdAmount,
@@ -560,32 +582,52 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         GoldMinterStorage storage $ = _getGoldMinterStorage();
 
         // Cache frequently used variables to reduce storage reads
-        uint16 slippage_ = $.slippage;
         IGoldMinter.Levels tradeLevel_ = $.tradeLevel;
+        uint256 tradeUnit_ = $.tradeUnit;
 
-        // Apply maximum 5% slippage
-        uint256 expectedOutput = getGoldAmount(_usdToken, _usdAmount);
-        uint256 feeAmount = calculateGoldFee(expectedOutput, true);
+        uint256 expectedOutput;
+        uint256 feeAmount;
+        uint256 actualUsdAmount;
 
-        // Validate request using extracted functions
-        _validateSlippage(expectedOutput - feeAmount, _minGoldAmount, slippage_);
-        // Validate gross minted amount >= minMintAmount (user may receive less after fee)
-        _validateMinimumAmount(expectedOutput, $.minMintAmount);
-        // commented out here to allow overbooking over reserves
-        _validateUserPermissions($, tradeLevel_);
+        if (tradeUnit_ > 0) {
+            // ── TradeUnit mode: gross gold is fixed to _minGoldAmount (must be tradeUnit multiple) ──
+            _validateTradeUnit(_minGoldAmount, tradeUnit_);
+
+            expectedOutput = _minGoldAmount; // gross gold = exact tradeUnit multiple
+            feeAmount = calculateGoldFee(expectedOutput, true);
+
+            _validateMinimumAmount(expectedOutput, $.minMintAmount);
+            _validateUserPermissions($, tradeLevel_);
+
+            // Calculate required USD (inverse of getGoldAmount, with ceiling)
+            actualUsdAmount = getRequiredUsd(_usdToken, expectedOutput);
+            if (actualUsdAmount > _usdAmount) revert Errors.InsufficientUsdAmount();
+        } else {
+            // ── Free mode: current behavior ──
+            uint16 slippage_ = $.slippage;
+
+            expectedOutput = getGoldAmount(_usdToken, _usdAmount);
+            feeAmount = calculateGoldFee(expectedOutput, true);
+
+            _validateSlippage(expectedOutput - feeAmount, _minGoldAmount, slippage_);
+            _validateMinimumAmount(expectedOutput, $.minMintAmount);
+            _validateUserPermissions($, tradeLevel_);
+
+            actualUsdAmount = _usdAmount;
+        }
 
         IERC20Exp usdToken = _getUSDToken($, _usdToken);
 
         uint256 mintNonce = $.mintOrders.length;
 
-        usdToken.safeTransferFrom(msg.sender, $.usdRecipient, _usdAmount);
+        usdToken.safeTransferFrom(msg.sender, $.usdRecipient, actualUsdAmount);
 
         $.mintOrders.push(
             IGoldMinter.MintOrder({
                 buyer: msg.sender,
                 usdToken: address(usdToken),
-                usdAmount: _usdAmount,
-                minGoldAmount: _minGoldAmount,
+                usdAmount: actualUsdAmount,
+                minGoldAmount: tradeUnit_ > 0 ? expectedOutput - feeAmount : _minGoldAmount,
                 goldAmount: expectedOutput,
                 feeAmount: feeAmount,
                 success: false,
@@ -595,7 +637,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
 
         $.userMintNonces[msg.sender].push(mintNonce);
 
-        emit RequestMint(mintNonce, msg.sender, address(usdToken), _usdAmount, _minGoldAmount);
+        emit RequestMint(mintNonce, msg.sender, address(usdToken), actualUsdAmount, _minGoldAmount);
 
         if ($.autoSettle) {
             _settleMint(mintNonce, expectedOutput);
@@ -611,6 +653,10 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         uint256 _minUsdAmount
     ) public nonReentrant whenNotPaused {
         GoldMinterStorage storage $ = _getGoldMinterStorage();
+
+        // TradeUnit validation: goldAmount must be a multiple of tradeUnit
+        uint256 tradeUnit_ = $.tradeUnit;
+        if (tradeUnit_ > 0) _validateTradeUnit(_goldAmount, tradeUnit_);
 
         // Cache frequently used variables to reduce storage reads
         uint16 slippage_ = $.slippage;
@@ -656,17 +702,15 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
     }
 
     function getGoldAmount(address usdToken, uint256 usdAmount) public view returns (uint256) {
-        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        (uint256 spreadAdjustedPrice, uint256 decimalFactor) = _getMintPriceParams(usdToken);
+        return (usdAmount * decimalFactor) / spreadAdjustedPrice;
+    }
 
-        (uint256 latestPrice, uint8 priceOracleDecimals) = _getValidatedPrice();
-        (uint8 goldDecimals, , , ) = _getTokenDecimals($);
-        uint8 usdDecimals = IERC20Exp(usdToken).decimals();
-
-        // Apply mintSpread: price increases by mintSpread% (user gets less gold)
-        // Formula: goldAmount = usdAmount / (price * (1 + spread))
-        uint256 spreadAdjustedPrice = (latestPrice * (10000 + $.mintSpread)) / 10000;
-
-        return (usdAmount * 10 ** (priceOracleDecimals + goldDecimals - usdDecimals)) / spreadAdjustedPrice;
+    /// @notice Inverse of getGoldAmount: calculate required USD for a given gold amount (with mintSpread, ceiling)
+    function getRequiredUsd(address usdToken, uint256 goldAmount) public view returns (uint256) {
+        (uint256 spreadAdjustedPrice, uint256 decimalFactor) = _getMintPriceParams(usdToken);
+        // Ceiling division: ensures enough USD to cover goldAmount
+        return (goldAmount * spreadAdjustedPrice + decimalFactor - 1) / decimalFactor;
     }
 
     function getUsdAmount(address usdToken, uint256 goldAmount) public view returns (uint256) {
@@ -733,6 +777,14 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         GoldMinterStorage storage $ = _getGoldMinterStorage();
         return $.minRedeemAmount;
     }
+    function tradeUnit() public view returns (uint256) {
+        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        return $.tradeUnit;
+    }
+    function feeRecipient() public view returns (address) {
+        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        return $.feeRecipient;
+    }
     function minGoldFee() public view returns (uint256) {
         GoldMinterStorage storage $ = _getGoldMinterStorage();
         return $.minGoldFee;
@@ -793,7 +845,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
             // Mint desired gold amount
         } else {
             $.mintOrders[mintNonce].goldAmount = goldAmount;
-            $.goldToken.mint($.usdRecipient, feeAmount);
+            $.goldToken.mint($.feeRecipient, feeAmount);
             $.goldToken.mint($.mintOrders[mintNonce].buyer, netGoldAmount);
         }
 
@@ -825,7 +877,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
             $.goldToken.safeTransfer($.burnOrders[burnNonce].seller, goldAmount);
         } else {
             $.goldToken.burn(goldAmount - feeAmount);
-            $.goldToken.safeTransfer($.usdRecipient, feeAmount);
+            $.goldToken.safeTransfer($.feeRecipient, feeAmount);
             usdToken.safeTransferFrom($.usdRecipient, $.burnOrders[burnNonce].seller, usdAmount);
         }
 
@@ -861,6 +913,16 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         if ($.amlBlacklist[msg.sender]) revert Errors.AMLBlocked();
     }
 
+    /// @dev Shared price params for mint-side calculations (getGoldAmount / getRequiredUsd)
+    function _getMintPriceParams(address usdToken) internal view returns (uint256 spreadAdjustedPrice, uint256 decimalFactor) {
+        GoldMinterStorage storage $ = _getGoldMinterStorage();
+        (uint256 latestPrice, uint8 priceOracleDecimals) = _getValidatedPrice();
+        (uint8 goldDecimals, , , ) = _getTokenDecimals($);
+        uint8 usdDecimals = IERC20Exp(usdToken).decimals();
+        spreadAdjustedPrice = (latestPrice * (10000 + $.mintSpread)) / 10000;
+        decimalFactor = 10 ** (priceOracleDecimals + goldDecimals - usdDecimals);
+    }
+
     /// @dev Common slippage validation logic
     function _validateSlippage(uint256 expectedOutput, uint256 minAmount, uint16 slippage_) internal pure {
         if (
@@ -872,6 +934,11 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
     /// @dev Common minimum amount validation
     function _validateMinimumAmount(uint256 amount, uint256 minRequired) internal pure {
         if (amount < minRequired) revert Errors.SmallAmount();
+    }
+
+    /// @dev Validate amount is a non-zero multiple of tradeUnit
+    function _validateTradeUnit(uint256 amount, uint256 tradeUnit_) internal pure {
+        if (amount == 0 || amount % tradeUnit_ != 0) revert Errors.NotTradeUnitMultiple();
     }
 
     /// @dev Process KYC verification and update user level
@@ -980,6 +1047,7 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
 
         emit UpdateTradingLevel($.tradeLevel);
         emit UpdateRecipient($.usdRecipient);
+        emit UpdateFeeRecipient($.feeRecipient);
 
         uint8 goldDecimals = $.goldToken.decimals();
         uint8 usdtDecimals = $.USDT.decimals();

--- a/contracts/GoldMinter.sol
+++ b/contracts/GoldMinter.sol
@@ -199,10 +199,10 @@ contract GoldMinter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, Pau
         $.redeemSpread = 75; // 0.75%
         $.mintFee = 25; // 0.25%
         $.redeemFee = 25; // 0.25%
-        $.minMintAmount = 1 ether; // 1 gram
-        $.minRedeemAmount = 1 ether; // 1 gram
-        $.minGoldFee = 0.01 ether; // 0.01 gram
-        $.minGoldFeeAmount = 1 ether; // 1 gram
+        $.minMintAmount = 1000 ether; // 1kg
+        $.minRedeemAmount = 1000 ether; // 1kg
+        $.minGoldFee = 2.5 ether; // 2.5 gram
+        $.minGoldFeeAmount = 1000 ether; // 1kg
         $.autoSettle = _autoSettle;
         $.tradeLevel = IGoldMinter.Levels.KYCD;
         $.usdRecipient = _usdRecipient;

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -20,6 +20,8 @@ library Errors {
     error SmallAmount();
     error Underlevel();
     error AMLBlocked();
+    error NotTradeUnitMultiple();
+    error InsufficientUsdAmount();
 
     // ============ Order Management Errors ============
     error InvalidNonce();

--- a/contracts/tokens/GoldToken.sol
+++ b/contracts/tokens/GoldToken.sol
@@ -48,7 +48,7 @@ contract GoldToken is InitializableERC20, AccessControlEnumerableUpgradeable {
 	// ============ Initializer ============
 
     function initializeGoldToken(address _initOwner, address _blacklistOracle) public initializer {
-        initializeToken('Arowana Gold Token', 'AGT', 18, 0);
+        initializeToken('Ontorium Gold Token', 'OXAU', 18, 0);
 		__AccessControl_init();
 
 		GoldTokenStorage storage $ = _getGoldTokenStorage();

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -20,8 +20,8 @@ import { getGoldPrice } from './goldPrice.js';
 
 const { viem } = await network.connect();
 
-const AGT_NAME = 'Arowana Gold Token';
-const AGT_SYMBOL = 'AGT';
+const AGT_NAME = 'Ontorium Gold Token';
+const AGT_SYMBOL = 'OXAU';
 const USD_TOKEN_DECIMALS = 6;
 const ORACLE_DECIMALS = 8;
 
@@ -262,6 +262,7 @@ async function deployGoldMinter(
             USDC.address,
             goldPriceFeed.address,
             owner.account!.address,
+            owner.account!.address, // feeRecipient
             owner.account!.address,
             true,
         ],

--- a/test/GoldMinter.ts
+++ b/test/GoldMinter.ts
@@ -55,7 +55,7 @@ describe('GoldMinter', function () {
 
         await goldTokenProxy.write.initializeProxy(
             [
-                'Arowana Gold Token',
+                'Ontorium Gold Token',
                 owner.account!.address,
                 goldTokenImplementation.address,
                 goldTokenInitData,
@@ -117,6 +117,7 @@ describe('GoldMinter', function () {
                 USDC.address,
                 goldPriceFeed.address,
                 owner.account.address,
+                owner.account.address, // feeRecipient
                 owner.account.address,
                 false,
             ],
@@ -176,6 +177,7 @@ describe('GoldMinter', function () {
                 USDC.address,
                 '0x0000000000000000000000000000000000000001',
                 owner.account.address,
+                owner.account.address, // feeRecipient
                 owner.account.address,
                 false,
             ],

--- a/test/GoldMinterEmergencyAML.ts
+++ b/test/GoldMinterEmergencyAML.ts
@@ -54,7 +54,7 @@ describe('GoldMinter - Emergency Pause & AML', function () {
 
         await goldTokenProxy.write.initializeProxy(
             [
-                'Arowana Gold Token',
+                'Ontorium Gold Token',
                 owner.account!.address,
                 goldTokenImplementation.address,
                 goldTokenInitData,
@@ -116,6 +116,7 @@ describe('GoldMinter - Emergency Pause & AML', function () {
                 USDC.address,
                 goldPriceFeed.address,
                 owner.account.address,
+                owner.account.address, // feeRecipient
                 owner.account.address,
                 true,
             ],

--- a/test/GoldMinterFullTest.ts
+++ b/test/GoldMinterFullTest.ts
@@ -56,7 +56,6 @@ describe('GoldMinter Full Test - Burn Settlement & Security', function () {
         const blacklistOracle = await viem.getContractAt('BlacklistOracle', blacklistOracleProxy.address);
 
         // ====== 2. Deploy GoldToken ======
-        // GoldToken: Gold token (AGT - Arowana Gold Token)
         const goldTokenImplementation = await viem.deployContract('GoldToken', []);
         const goldTokenProxy = await viem.deployContract('InitializableProxy', []);
 
@@ -68,7 +67,7 @@ describe('GoldMinter Full Test - Burn Settlement & Security', function () {
 
         await goldTokenProxy.write.initializeProxy(
             [
-                'Arowana Gold Token',
+                'Ontorium Gold Token',
                 owner.account!.address,
                 goldTokenImplementation.address,
                 goldTokenInitData,
@@ -138,6 +137,7 @@ describe('GoldMinter Full Test - Burn Settlement & Security', function () {
                 USDC.address, // USDC address
                 goldPriceFeed.address, // Price feed address
                 owner.account.address, // usdRecipient (Treasury - USD recipient address)
+                owner.account.address, // feeRecipient
                 owner.account.address, // owner (contract owner)
                 true, // autoSettle: true (enable auto settlement)
             ],

--- a/test/GoldMinterTradeUnit.ts
+++ b/test/GoldMinterTradeUnit.ts
@@ -1,0 +1,989 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai';
+import { parseUnits, parseEther, maxUint256, encodeFunctionData } from 'viem';
+import { getClients } from './helpers.js';
+
+const GOLD_PRICE = parseUnits('4096.342', 8);
+
+const TRADE_UNIT_1KG = parseEther('1000');
+const TRADE_UNIT_100G = parseEther('100');
+const TRADE_UNIT_1G = parseEther('1');
+
+describe('GoldMinter TradeUnit', function () {
+    const fixture = async () => {
+        const { owner, buyer, bob, viem } = await getClients();
+
+        // Mock tokens
+        const USDT = await viem.deployContract('ERC20Mock', [
+            'Tether USD',
+            'USDT',
+            6,
+            parseUnits('100000000', 6),
+        ]);
+
+        // BlacklistOracle
+        const boImpl = await viem.deployContract('BlacklistOracle', []);
+        const boProxy = await viem.deployContract('InitializableProxy', []);
+        await boProxy.write.initializeProxy(
+            [
+                'Blacklist Oracle',
+                owner.account.address,
+                boImpl.address,
+                encodeFunctionData({
+                    abi: boImpl.abi,
+                    functionName: 'initializeOracle',
+                    args: ['Blacklist Oracle', owner.account.address],
+                }),
+            ],
+            { account: owner.account },
+        );
+
+        // GoldToken
+        const gtImpl = await viem.deployContract('GoldToken', []);
+        const gtProxy = await viem.deployContract('InitializableProxy', []);
+        await gtProxy.write.initializeProxy(
+            [
+                'Ontorium Gold Token',
+                owner.account.address,
+                gtImpl.address,
+                encodeFunctionData({
+                    abi: gtImpl.abi,
+                    functionName: 'initializeGoldToken',
+                    args: [owner.account.address, boProxy.address],
+                }),
+            ],
+            { account: owner.account },
+        );
+        const goldToken = await viem.getContractAt('GoldToken', gtProxy.address);
+
+        // PriceFeed
+        const pfImpl = await viem.deployContract('DataFeed');
+        const pfProxy = await viem.deployContract('InitializableProxy', []);
+        await pfProxy.write.initializeProxy(
+            [
+                'DataFeed',
+                owner.account.address,
+                pfImpl.address,
+                encodeFunctionData({
+                    abi: pfImpl.abi,
+                    functionName: 'initializeFeed',
+                    args: [owner.account.address, gtProxy.address, 'OXAU / USD'],
+                }),
+            ],
+            { account: owner.account },
+        );
+        const goldPriceFeed = await viem.getContractAt('DataFeed', pfProxy.address);
+        await goldPriceFeed.write.updateAnswer([GOLD_PRICE], { account: owner.account });
+
+        // GoldMinter (autoSettle=true)
+        const gmImpl = await viem.deployContract('GoldMinter');
+        const gmProxy = await viem.deployContract('InitializableProxy', []);
+        await gmProxy.write.initializeProxy(
+            [
+                'GoldMinter',
+                owner.account.address,
+                gmImpl.address,
+                encodeFunctionData({
+                    abi: gmImpl.abi,
+                    functionName: 'initializeGoldMinter',
+                    args: [
+                        gtProxy.address,
+                        USDT.address,
+                        USDT.address, // USDC = USDT for simplicity
+                        pfProxy.address,
+                        owner.account.address, // usdRecipient
+                        owner.account.address, // feeRecipient
+                        owner.account.address,
+                        true, // autoSettle
+                    ],
+                }),
+            ],
+            { account: owner.account },
+        );
+        const goldMinter = await viem.getContractAt('GoldMinter', gmProxy.address);
+
+        // Roles
+        await goldToken.write.addMinter([goldMinter.address], { account: owner.account });
+        const SETTLER_ROLE = await goldMinter.read.SETTLER_ROLE();
+        const PARAMETER_MANAGER_ROLE = await goldMinter.read.PARAMETER_MANAGER_ROLE();
+        const KYC_MANAGER_ROLE = await goldMinter.read.KYC_MANAGER_ROLE();
+        await goldMinter.write.grantRole([SETTLER_ROLE, owner.account.address], { account: owner.account });
+        await goldMinter.write.grantRole([PARAMETER_MANAGER_ROLE, owner.account.address], {
+            account: owner.account,
+        });
+        await goldMinter.write.grantRole([KYC_MANAGER_ROLE, owner.account.address], {
+            account: owner.account,
+        });
+
+        // KYC + funds for buyer
+        await goldMinter.write.setLevel([buyer.account.address, 2], { account: owner.account });
+        await USDT.write.transfer([buyer.account.address, parseUnits('10000000', 6)], {
+            account: owner.account,
+        });
+        await USDT.write.approve([goldMinter.address, maxUint256], { account: buyer.account });
+        await goldToken.write.approve([goldMinter.address, maxUint256], { account: buyer.account });
+
+        // usdRecipient (owner) approve for redeem settlement
+        await USDT.write.approve([goldMinter.address, maxUint256], { account: owner.account });
+
+        return { owner, buyer, bob, goldToken, USDT, goldPriceFeed, goldMinter, viem };
+    };
+
+    describe('Mint — tradeUnit default mode', function () {
+        it('1kg mint — gross gold is exactly 1kg, buyer receives net gold', async function () {
+            const f = await fixtureWithTradeUnit();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+            const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            const received = goldAfter - goldBefore;
+
+            expect(received).to.equal(grossGold - fee);
+            expect(received + fee).to.equal(grossGold);
+        });
+    });
+
+    // Shared fixture with tradeUnit pre-set
+    const fixtureWithTradeUnit = async (tradeUnit: bigint = TRADE_UNIT_1KG) => {
+        const f = await fixture();
+        await f.goldMinter.write.updateTradeUnit([tradeUnit], { account: f.owner.account });
+        return f;
+    };
+
+    // Helper: mint gold for user
+    async function mintForBuyer(f: any, units: bigint, tradeUnit: bigint = TRADE_UNIT_1KG) {
+        const grossGold = units * tradeUnit;
+        const requiredUsd = (await f.goldMinter.read.getRequiredUsd([f.USDT.address, grossGold])) as bigint;
+        await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+            account: f.buyer.account,
+        });
+        return grossGold;
+    }
+
+    describe('2. Various unit mints', function () {
+        for (const units of [1n, 2n, 3n, 5n, 10n]) {
+            it(`${units}kg mint success`, async function () {
+                const f = await fixtureWithTradeUnit();
+                const grossGold = units * TRADE_UNIT_1KG;
+                const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                    f.USDT.address,
+                    grossGold,
+                ])) as bigint;
+                const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+                const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+                await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                    account: f.buyer.account,
+                });
+
+                const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+                expect(goldAfter - goldBefore).to.equal(grossGold - fee);
+            });
+        }
+    });
+
+    describe('3. Non-multiple amounts rejected', function () {
+        it('500g mint rejected (tradeUnit=1kg)', async function () {
+            const f = await fixtureWithTradeUnit();
+            const invalidAmount = parseEther('500');
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint([f.USDT.address, parseUnits('1000000', 6), invalidAmount], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+
+        it('1500g mint rejected (tradeUnit=1kg)', async function () {
+            const f = await fixtureWithTradeUnit();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint(
+                    [f.USDT.address, parseUnits('1000000', 6), parseEther('1500')],
+                    {
+                        account: f.buyer.account,
+                    },
+                ),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+
+        it('0g mint rejected', async function () {
+            const f = await fixtureWithTradeUnit();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint([f.USDT.address, parseUnits('1000000', 6), 0n], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+    });
+
+    // 4. Redeem tradeUnit validation
+
+    describe('4. Redeem tradeUnit validation', function () {
+        it('1kg redeem success', async function () {
+            const f = await fixtureWithTradeUnit();
+            await mintForBuyer(f, 2n);
+
+            const redeemGold = TRADE_UNIT_1KG;
+            const fee = (await f.goldMinter.read.calculateGoldFee([redeemGold, false])) as bigint;
+            const expectedUsd = (await f.goldMinter.read.getUsdAmount([
+                f.USDT.address,
+                redeemGold - fee,
+            ])) as bigint;
+            const minUsd = (expectedUsd * 9500n) / 10000n;
+
+            const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestBurn([f.USDT.address, redeemGold, minUsd], {
+                account: f.buyer.account,
+            });
+
+            const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            // buyer gold should decrease (fee goes to feeRecipient)
+            expect(goldBefore - goldAfter).to.be.greaterThan(0);
+        });
+
+        it('500g redeem rejected (tradeUnit=1kg)', async function () {
+            const f = await fixtureWithTradeUnit();
+            await mintForBuyer(f, 1n);
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestBurn([f.USDT.address, parseEther('500'), 0n], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+
+        it('0g redeem rejected', async function () {
+            const f = await fixtureWithTradeUnit();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestBurn([f.USDT.address, 0n, 0n], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+    });
+
+    // 5. USD cap protection (InsufficientUsdAmount)
+
+    describe('5. USD cap protection', function () {
+        it('_usdAmount < requiredUsd should revert', async function () {
+            const f = await fixtureWithTradeUnit();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            // set 1 wei less than required
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint([f.USDT.address, requiredUsd - 1n, grossGold], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'InsufficientUsdAmount',
+            );
+        });
+
+        it('_usdAmount == requiredUsd should succeed', async function () {
+            const f = await fixtureWithTradeUnit();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            // exactly requiredUsd
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+        });
+
+        it('_usdAmount > requiredUsd should succeed (excess not transferred)', async function () {
+            const f = await fixtureWithTradeUnit();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            const usdBefore = (await f.USDT.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            // set 2x
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd * 2n, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const usdAfter = (await f.USDT.read.balanceOf([f.buyer.account.address])) as bigint;
+            // actual transfer = requiredUsd (not 2x)
+            expect(usdBefore - usdAfter).to.equal(requiredUsd);
+        });
+    });
+
+    // 6. getRequiredUsd ↔ getGoldAmount consistency
+
+    describe('6. getRequiredUsd ↔ getGoldAmount consistency', function () {
+        it('getGoldAmount(getRequiredUsd(G)) >= G', async function () {
+            const f = await fixtureWithTradeUnit();
+
+            for (const units of [1n, 2n, 5n, 10n]) {
+                const G = units * TRADE_UNIT_1KG;
+                const U = (await f.goldMinter.read.getRequiredUsd([f.USDT.address, G])) as bigint;
+                const G2 = (await f.goldMinter.read.getGoldAmount([f.USDT.address, U])) as bigint;
+                expect(G2 >= G).to.be.true;
+            }
+        });
+    });
+
+    // 7. Fee accuracy
+
+    describe('7. Fee accuracy', function () {
+        it('1kg mint fee = 1000g × 0.25% = 2.5g', async function () {
+            const f = await fixtureWithTradeUnit();
+            const fee = (await f.goldMinter.read.calculateGoldFee([TRADE_UNIT_1KG, true])) as bigint;
+            expect(fee).to.equal(parseEther('2.5'));
+        });
+
+        it('5kg mint fee = 5000g × 0.25% = 12.5g', async function () {
+            const f = await fixtureWithTradeUnit();
+            const fee = (await f.goldMinter.read.calculateGoldFee([5n * TRADE_UNIT_1KG, true])) as bigint;
+            expect(fee).to.equal(parseEther('12.5'));
+        });
+
+        it('gross - fee = gold received by buyer', async function () {
+            const f = await fixtureWithTradeUnit();
+            const grossGold = TRADE_UNIT_1KG;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            expect(goldAfter - goldBefore).to.equal(grossGold - fee);
+        });
+    });
+
+    // 8. Mode switching (tradeUnit → 0 → tradeUnit)
+
+    describe('8. Mode switching', function () {
+        it('tradeUnit=1kg → 0 → 1kg switching works correctly in each mode', async function () {
+            const f = await fixture();
+
+            // Phase 1: tradeUnit = 1kg
+            await f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.owner.account });
+            expect(await f.goldMinter.read.tradeUnit()).to.equal(TRADE_UNIT_1KG);
+
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                TRADE_UNIT_1KG,
+            ])) as bigint;
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, TRADE_UNIT_1KG], {
+                account: f.buyer.account,
+            });
+
+            // Phase 2: tradeUnit = 0 (free mode)
+            await f.goldMinter.write.updateTradeUnit([0n], { account: f.owner.account });
+            expect(await f.goldMinter.read.tradeUnit()).to.equal(0n);
+
+            // 500g mint possible in free mode
+            const usdFor500g = parseUnits('70000', 6);
+            const expectedGold = (await f.goldMinter.read.getGoldAmount([
+                f.USDT.address,
+                usdFor500g,
+            ])) as bigint;
+            const expectedFee = (await f.goldMinter.read.calculateGoldFee([expectedGold, true])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, usdFor500g, expectedGold - expectedFee], {
+                account: f.buyer.account,
+            });
+
+            // Phase 3: tradeUnit = 1kg again
+            await f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.owner.account });
+
+            // 500g rejected again
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint(
+                    [f.USDT.address, parseUnits('1000000', 6), parseEther('500')],
+                    {
+                        account: f.buyer.account,
+                    },
+                ),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+
+            // 1kg succeeds again
+            const requiredUsd2 = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                TRADE_UNIT_1KG,
+            ])) as bigint;
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd2, TRADE_UNIT_1KG], {
+                account: f.buyer.account,
+            });
+        });
+    });
+
+    // 9. Manual Settlement + mode switching
+
+    describe('9. Manual Settlement + mode switching', function () {
+        it('order at tradeUnit=1kg → change to tradeUnit=0 → existing order settles correctly', async function () {
+            const f = await fixture();
+
+            // disable autoSettle
+            await f.goldMinter.write.updateAutoSettle([], { account: f.owner.account });
+            await f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.owner.account });
+
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+            const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            // create order (tradeUnit=1kg active)
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            // not yet settled
+            expect((await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint).to.equal(
+                goldBefore,
+            );
+
+            // change tradeUnit to 0
+            await f.goldMinter.write.updateTradeUnit([0n], { account: f.owner.account });
+
+            // settle existing order (settler)
+            const nonces = (await f.goldMinter.read.getUserMintNonces([
+                f.buyer.account.address,
+                0n,
+                100n,
+            ])) as bigint[];
+            await f.goldMinter.write.settleMint([nonces[nonces.length - 1]], {
+                account: f.owner.account,
+            });
+
+            // verify gold received after settlement — settled per request-time conditions (1kg)
+            const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            expect(goldAfter - goldBefore).to.equal(grossGold - fee);
+        });
+    });
+
+    // 10. Various tradeUnit sizes
+
+    describe('10. Various tradeUnit sizes', function () {
+        it('tradeUnit=100g — 300g mint success', async function () {
+            const f = await fixtureWithTradeUnit(TRADE_UNIT_100G);
+            const grossGold = 3n * TRADE_UNIT_100G; // 300g
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+            const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+            const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            expect(goldAfter - goldBefore).to.equal(grossGold - fee);
+        });
+
+        it('tradeUnit=100g — 150g mint rejected', async function () {
+            const f = await fixtureWithTradeUnit(TRADE_UNIT_100G);
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint(
+                    [f.USDT.address, parseUnits('1000000', 6), parseEther('150')],
+                    {
+                        account: f.buyer.account,
+                    },
+                ),
+                f.goldMinter,
+                'NotTradeUnitMultiple',
+            );
+        });
+
+        it('tradeUnit=1g — 7g mint success', async function () {
+            const f = await fixtureWithTradeUnit(TRADE_UNIT_1G);
+            const grossGold = 7n * TRADE_UNIT_1G;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+        });
+    });
+
+    // 11. Access control
+
+    describe('11. Access control', function () {
+        it('only PARAMETER_MANAGER can call updateTradeUnit', async function () {
+            const f = await fixture();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.buyer.account }),
+                f.goldMinter,
+                'AccessControlUnauthorizedAccount',
+            );
+        });
+
+        it('PARAMETER_MANAGER can updateTradeUnit successfully', async function () {
+            const f = await fixture();
+            await f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.owner.account });
+            expect(await f.goldMinter.read.tradeUnit()).to.equal(TRADE_UNIT_1KG);
+        });
+    });
+
+    // 12. Emergency Pause + tradeUnit
+
+    describe('12. Emergency Pause + tradeUnit', function () {
+        it('tradeUnit mint blocked during pause', async function () {
+            const f = await fixtureWithTradeUnit();
+            await f.goldMinter.write.emergencyPause([], { account: f.owner.account });
+
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'EnforcedPause',
+            );
+
+            // succeeds after unpause
+            await f.goldMinter.write.emergencyUnpause([], { account: f.owner.account });
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+        });
+    });
+
+    // 13. Various gold prices
+
+    describe('13. Various gold prices', function () {
+        const prices = [
+            { price: parseUnits('2500.50', 8), label: '$2500.50/oz' },
+            { price: parseUnits('4684.70', 8), label: '$4684.70/oz' },
+            { price: parseUnits('5999.999999', 8), label: '$5999.999999/oz' },
+        ];
+
+        for (const { price, label } of prices) {
+            it(`${label} — 1kg mint exact`, async function () {
+                const f = await fixtureWithTradeUnit();
+
+                await f.goldPriceFeed.write.updateAnswer([price], { account: f.owner.account });
+
+                const grossGold = TRADE_UNIT_1KG;
+                const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                    f.USDT.address,
+                    grossGold,
+                ])) as bigint;
+                const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+                const goldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+                await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                    account: f.buyer.account,
+                });
+
+                const goldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+                expect(goldAfter - goldBefore).to.equal(grossGold - fee);
+            });
+        }
+    });
+
+    // 14. tradeUnit=0 (free mode) no regression
+    describe('14. tradeUnit=0 — free mode no regression', function () {
+        it('free mode allows arbitrary amount mint', async function () {
+            const f = await fixture(); // tradeUnit default = 0
+            expect(await f.goldMinter.read.tradeUnit()).to.equal(0n);
+
+            const usdAmount = parseUnits('500', 6);
+            const expectedGold = (await f.goldMinter.read.getGoldAmount([
+                f.USDT.address,
+                usdAmount,
+            ])) as bigint;
+            const expectedFee = (await f.goldMinter.read.calculateGoldFee([expectedGold, true])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, usdAmount, expectedGold - expectedFee], {
+                account: f.buyer.account,
+            });
+
+            const balance = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            expect(balance).to.be.greaterThan(0);
+        });
+
+        it('free mode allows non-multiple amounts', async function () {
+            const f = await fixture();
+
+            const usdAmount = parseUnits('777.77', 6);
+            const expectedGold = (await f.goldMinter.read.getGoldAmount([
+                f.USDT.address,
+                usdAmount,
+            ])) as bigint;
+            const expectedFee = (await f.goldMinter.read.calculateGoldFee([expectedGold, true])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, usdAmount, expectedGold - expectedFee], {
+                account: f.buyer.account,
+            });
+        });
+    });
+
+    // 15. Double settlement prevention
+
+    describe('15. Double settlement prevention', function () {
+        it('manual settle after auto-settle should revert', async function () {
+            const f = await fixtureWithTradeUnit();
+
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            // already settled via auto-settle. attempt manual settle
+            const nonces = (await f.goldMinter.read.getUserMintNonces([
+                f.buyer.account.address,
+                0n,
+                100n,
+            ])) as bigint[];
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.settleMint([nonces[0]], { account: f.owner.account }),
+                f.goldMinter,
+                'AlreadySettled',
+            );
+        });
+    });
+
+    // 16. feeRecipient separation test
+
+    describe('16. feeRecipient separation', function () {
+        // bob = feeRecipient, owner = usdRecipient separated fixture
+        const fixtureWithSeparateFee = async () => {
+            const { owner, buyer, bob, viem } = await getClients();
+
+            const USDT = await viem.deployContract('ERC20Mock', [
+                'Tether USD',
+                'USDT',
+                6,
+                parseUnits('100000000', 6),
+            ]);
+
+            const boImpl = await viem.deployContract('BlacklistOracle', []);
+            const boProxy = await viem.deployContract('InitializableProxy', []);
+            await boProxy.write.initializeProxy(
+                [
+                    'Blacklist Oracle',
+                    owner.account.address,
+                    boImpl.address,
+                    encodeFunctionData({
+                        abi: boImpl.abi,
+                        functionName: 'initializeOracle',
+                        args: ['Blacklist Oracle', owner.account.address],
+                    }),
+                ],
+                { account: owner.account },
+            );
+
+            const gtImpl = await viem.deployContract('GoldToken', []);
+            const gtProxy = await viem.deployContract('InitializableProxy', []);
+            await gtProxy.write.initializeProxy(
+                [
+                    'Ontorium Gold Token',
+                    owner.account.address,
+                    gtImpl.address,
+                    encodeFunctionData({
+                        abi: gtImpl.abi,
+                        functionName: 'initializeGoldToken',
+                        args: [owner.account.address, boProxy.address],
+                    }),
+                ],
+                { account: owner.account },
+            );
+            const goldToken = await viem.getContractAt('GoldToken', gtProxy.address);
+
+            const pfImpl = await viem.deployContract('DataFeed');
+            const pfProxy = await viem.deployContract('InitializableProxy', []);
+            await pfProxy.write.initializeProxy(
+                [
+                    'DataFeed',
+                    owner.account.address,
+                    pfImpl.address,
+                    encodeFunctionData({
+                        abi: pfImpl.abi,
+                        functionName: 'initializeFeed',
+                        args: [owner.account.address, gtProxy.address, 'OXAU / USD'],
+                    }),
+                ],
+                { account: owner.account },
+            );
+            const goldPriceFeed = await viem.getContractAt('DataFeed', pfProxy.address);
+            await goldPriceFeed.write.updateAnswer([GOLD_PRICE], { account: owner.account });
+
+            const gmImpl = await viem.deployContract('GoldMinter');
+            const gmProxy = await viem.deployContract('InitializableProxy', []);
+            await gmProxy.write.initializeProxy(
+                [
+                    'GoldMinter',
+                    owner.account.address,
+                    gmImpl.address,
+                    encodeFunctionData({
+                        abi: gmImpl.abi,
+                        functionName: 'initializeGoldMinter',
+                        args: [
+                            gtProxy.address,
+                            USDT.address,
+                            USDT.address,
+                            pfProxy.address,
+                            owner.account.address, // usdRecipient = owner
+                            bob.account.address, // feeRecipient = bob (separated)
+                            owner.account.address, // admin
+                            true,
+                        ],
+                    }),
+                ],
+                { account: owner.account },
+            );
+            const goldMinter = await viem.getContractAt('GoldMinter', gmProxy.address);
+
+            await goldToken.write.addMinter([goldMinter.address], { account: owner.account });
+            const SETTLER_ROLE = await goldMinter.read.SETTLER_ROLE();
+            const PARAMETER_MANAGER_ROLE = await goldMinter.read.PARAMETER_MANAGER_ROLE();
+            const INFRA_MANAGER_ROLE = await goldMinter.read.INFRA_MANAGER_ROLE();
+            const KYC_MANAGER_ROLE = await goldMinter.read.KYC_MANAGER_ROLE();
+            await goldMinter.write.grantRole([SETTLER_ROLE, owner.account.address], {
+                account: owner.account,
+            });
+            await goldMinter.write.grantRole([PARAMETER_MANAGER_ROLE, owner.account.address], {
+                account: owner.account,
+            });
+            await goldMinter.write.grantRole([INFRA_MANAGER_ROLE, owner.account.address], {
+                account: owner.account,
+            });
+            await goldMinter.write.grantRole([KYC_MANAGER_ROLE, owner.account.address], {
+                account: owner.account,
+            });
+
+            await goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: owner.account });
+            await goldMinter.write.setLevel([buyer.account.address, 2], { account: owner.account });
+
+            await USDT.write.transfer([buyer.account.address, parseUnits('10000000', 6)], {
+                account: owner.account,
+            });
+            await USDT.write.approve([goldMinter.address, maxUint256], { account: buyer.account });
+            await goldToken.write.approve([goldMinter.address, maxUint256], { account: buyer.account });
+            await USDT.write.approve([goldMinter.address, maxUint256], { account: owner.account });
+
+            return { owner, buyer, bob, goldToken, USDT, goldPriceFeed, goldMinter, viem };
+        };
+
+        it('Mint — gold fee goes to feeRecipient(bob), USD goes to usdRecipient(owner)', async function () {
+            const f = await fixtureWithSeparateFee();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+            const bobGoldBefore = (await f.goldToken.read.balanceOf([f.bob.account.address])) as bigint;
+            const ownerUsdBefore = (await f.USDT.read.balanceOf([f.owner.account.address])) as bigint;
+            const buyerGoldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const bobGoldAfter = (await f.goldToken.read.balanceOf([f.bob.account.address])) as bigint;
+            const ownerUsdAfter = (await f.USDT.read.balanceOf([f.owner.account.address])) as bigint;
+            const buyerGoldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            // feeRecipient(bob) receives gold fee
+            expect(bobGoldAfter - bobGoldBefore).to.equal(fee);
+            // usdRecipient(owner) receives USD
+            expect(ownerUsdAfter - ownerUsdBefore).to.equal(requiredUsd);
+            // buyer receives net gold
+            expect(buyerGoldAfter - buyerGoldBefore).to.equal(grossGold - fee);
+            // total gold = fee + net = gross
+            expect(bobGoldAfter - bobGoldBefore + (buyerGoldAfter - buyerGoldBefore)).to.equal(grossGold);
+        });
+
+        it('Redeem — gold fee goes to feeRecipient(bob), USD paid from usdRecipient(owner)', async function () {
+            const f = await fixtureWithSeparateFee();
+
+            // mint 2kg first (secure gold for redeem)
+            const mintGold = 2n * TRADE_UNIT_1KG;
+            const mintUsd = (await f.goldMinter.read.getRequiredUsd([f.USDT.address, mintGold])) as bigint;
+            await f.goldMinter.write.requestMint([f.USDT.address, mintUsd, mintGold], {
+                account: f.buyer.account,
+            });
+
+            // prepare redeem
+            const redeemGold = TRADE_UNIT_1KG;
+            const redeemFee = (await f.goldMinter.read.calculateGoldFee([redeemGold, false])) as bigint;
+            const expectedUsd = (await f.goldMinter.read.getUsdAmount([
+                f.USDT.address,
+                redeemGold - redeemFee,
+            ])) as bigint;
+            const minUsd = (expectedUsd * 9500n) / 10000n;
+
+            const bobGoldBefore = (await f.goldToken.read.balanceOf([f.bob.account.address])) as bigint;
+            const ownerUsdBefore = (await f.USDT.read.balanceOf([f.owner.account.address])) as bigint;
+            const buyerUsdBefore = (await f.USDT.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestBurn([f.USDT.address, redeemGold, minUsd], {
+                account: f.buyer.account,
+            });
+
+            const bobGoldAfter = (await f.goldToken.read.balanceOf([f.bob.account.address])) as bigint;
+            const ownerUsdAfter = (await f.USDT.read.balanceOf([f.owner.account.address])) as bigint;
+            const buyerUsdAfter = (await f.USDT.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            // feeRecipient(bob) receives gold fee
+            expect(bobGoldAfter - bobGoldBefore).to.equal(redeemFee);
+            // USD withdrawn from usdRecipient(owner)
+            expect(ownerUsdBefore - ownerUsdAfter).to.be.greaterThan(0);
+            // buyer receives USD
+            expect(buyerUsdAfter - buyerUsdBefore).to.be.greaterThan(0);
+        });
+
+        it('usdRecipient gold balance unchanged (fee only goes to feeRecipient)', async function () {
+            const f = await fixtureWithSeparateFee();
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            const ownerGoldBefore = (await f.goldToken.read.balanceOf([f.owner.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const ownerGoldAfter = (await f.goldToken.read.balanceOf([f.owner.account.address])) as bigint;
+
+            // usdRecipient(owner) does not receive gold
+            expect(ownerGoldAfter).to.equal(ownerGoldBefore);
+        });
+
+        it('updateFeeRecipient — only INFRA_MANAGER allowed', async function () {
+            const f = await fixtureWithSeparateFee();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.updateFeeRecipient([f.buyer.account.address], {
+                    account: f.buyer.account,
+                }),
+                f.goldMinter,
+                'AccessControlUnauthorizedAccount',
+            );
+        });
+
+        it('updateFeeRecipient — fee goes to new address after change', async function () {
+            const f = await fixtureWithSeparateFee();
+
+            // change feeRecipient to buyer
+            await f.goldMinter.write.updateFeeRecipient([f.buyer.account.address], {
+                account: f.owner.account,
+            });
+            const stored = (await f.goldMinter.read.feeRecipient()) as string;
+            expect(stored.toLowerCase()).to.equal(f.buyer.account.address.toLowerCase());
+
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+
+            const buyerGoldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const buyerGoldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            // buyer receives both net gold + fee gold (buyer = feeRecipient)
+            expect(buyerGoldAfter - buyerGoldBefore).to.equal(grossGold);
+        });
+
+        it('updateFeeRecipient — address(0) rejected', async function () {
+            const f = await fixtureWithSeparateFee();
+
+            await f.viem.assertions.revertWithCustomError(
+                f.goldMinter.write.updateFeeRecipient(['0x0000000000000000000000000000000000000000'], {
+                    account: f.owner.account,
+                }),
+                f.goldMinter,
+                'ZeroRecipient',
+            );
+        });
+
+        it('feeRecipient == usdRecipient same address — backward compatible', async function () {
+            const f = await fixture(); // default fixture: owner = usdRecipient = feeRecipient
+            await f.goldMinter.write.updateTradeUnit([TRADE_UNIT_1KG], { account: f.owner.account });
+
+            const grossGold = TRADE_UNIT_1KG;
+            const requiredUsd = (await f.goldMinter.read.getRequiredUsd([
+                f.USDT.address,
+                grossGold,
+            ])) as bigint;
+            const fee = (await f.goldMinter.read.calculateGoldFee([grossGold, true])) as bigint;
+
+            const buyerGoldBefore = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+
+            await f.goldMinter.write.requestMint([f.USDT.address, requiredUsd, grossGold], {
+                account: f.buyer.account,
+            });
+
+            const buyerGoldAfter = (await f.goldToken.read.balanceOf([f.buyer.account.address])) as bigint;
+            expect(buyerGoldAfter - buyerGoldBefore).to.equal(grossGold - fee);
+        });
+    });
+});

--- a/test/GoldMinterUpgrade.ts
+++ b/test/GoldMinterUpgrade.ts
@@ -53,7 +53,7 @@ describe('GoldMinter - Upgrade Tests', function () {
 
         await goldTokenProxy.write.initializeProxy(
             [
-                'Arowana Gold Token',
+                'Ontorium Gold Token',
                 owner.account!.address,
                 goldTokenImplementation.address,
                 goldTokenInitData,
@@ -115,6 +115,7 @@ describe('GoldMinter - Upgrade Tests', function () {
                 USDC.address,
                 goldPriceFeed.address,
                 owner.account.address,
+                owner.account.address, // feeRecipient
                 owner.account.address,
                 true,
             ],

--- a/test/GoldToken.ts
+++ b/test/GoldToken.ts
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import { parseEther, zeroAddress, getAddress, maxUint256, encodeFunctionData } from 'viem';
 import { getClients, signPermitERC2612 } from './helpers.js';
 
-const TOKEN_NAME = 'Arowana Gold Token';
-const TOKEN_SYMBOL = 'AGT';
+const TOKEN_NAME = 'Ontorium Gold Token';
+const TOKEN_SYMBOL = 'OXAU';
 const TOKEN_DECIMALS = 18;
 
 // AccessControl role constants


### PR DESCRIPTION
### 요약                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                
  - 정확한 kg 단위 민트/리딤을 위한 `tradeUnit` 기능 추가                                                                                                                                                                                                                                                       
  - 수수료 지갑(`feeRecipient`)과 재무 지갑(`usdRecipient`) 분리
  - 토큰명 AGT → OXAU (Ontorium Gold Token) 변경

## 변경 내용                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                
  ### GoldMinter.sol                                        
  - `tradeUnit` 스토리지 + `updateTradeUnit()` (PARAMETER_MANAGER_ROLE)
  - `feeRecipient` 스토리지 + `updateFeeRecipient()` (INFRA_MANAGER_ROLE)                                                                                                                                                                                                                                       
  - `getRequiredUsd()`: `getGoldAmount()`의 역함수 (올림 처리). gold 수량 기준으로 필요 USD 계산
  - `_getMintPriceParams()`: 가격 계산 공통 헬퍼 추출 (코드 중복 제거)                                                                                                                                                                                                                                          
  - `_validateTradeUnit()`: tradeUnit 배수 검증 공통 헬퍼                                                                                                                                                                                                                                                       
  - `requestMint()`: tradeUnit 모드 분기 — gold 수량 확정 → USD 역산 → 필요 금액만 전송                                                                                                                                                                                                                         
  - `requestBurn()`: tradeUnit 배수 검증 추가                                                                                                                                                                                                                                                                   
  - `_settleMint` / `_settleBurn`: gold 수수료를 `feeRecipient`로 전송 (기존 `usdRecipient`에서 분리)                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                
  ### Errors.sol                                            
  - `NotTradeUnitMultiple`: tradeUnit 배수가 아닌 금액 거부                                                                                                                                                                                                                                                     
  - `InsufficientUsdAmount`: 필요 USD보다 적은 금액 거부                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                
  ### GoldToken.sol                                                                                                                                                                                                                                                                                             
  - 토큰 이름/심볼: Ontorium Gold Token / OXAU

### 테스트
  - `GoldMinterTradeUnit.ts`: 40개 테스트 케이스
    - 1~10kg 민트 (gross gold 정확히 kg 배수 검증)                                                                                                                                                                                                                                                              
    - 비배수 금액 거부 (500g, 1500g, 0g)                                                                                                                                                                                                                                                                        
    - 리딤 tradeUnit 검증                                                                                                                                                                                                                                                                                       
    - USD cap 보호 (부족/정확/초과)                                                                                                                                                                                                                                                                             
    - getRequiredUsd ↔ getGoldAmount 수학적 일관성                                                                                                                                                                                                                                                              
    - 수수료 정확성 (1kg=2.5g, 5kg=12.5g)                                                                                                                                                                                                                                                                       
    - 모드 전환 (tradeUnit → free → tradeUnit)                                                                                                                                                                                                                                                                  
    - 모드 전환 중 pending order 정산                       
    - 다양한 tradeUnit 크기 (1kg, 100g, 1g)                                                                                                                                                                                                                                                                     
    - 권한 검증 (updateTradeUnit, updateFeeRecipient)       
    - 긴급 정지 + tradeUnit                                                                                                                                                                                                                                                                                     
    - 다양한 금 가격 ($2,500~$5,999)                        
    - free mode 퇴행 없음                                                                                                                                                                                                                                                                                       
    - 이중 정산 방지                                        
    - feeRecipient 분리 (민트/리딤 자금 흐름)                                                                                                                                                                                                                                                                   
    - feeRecipient == usdRecipient 하위 호환